### PR TITLE
Register mouse drag only after movement threshold is reached

### DIFF
--- a/src/com/komiamiko/fcorbit/CommandNone.java
+++ b/src/com/komiamiko/fcorbit/CommandNone.java
@@ -73,7 +73,7 @@ public class CommandNone implements ActiveCommand{
 					view.repaint();
 				}
 			}else{
-				int mx = e.getX(), my = e.getY();
+				int mx = view.originMousex, my = view.originMousey;
 				FCObj sel = view.getSelectionPoint(mx,my);
 				if(sel!=null){// Something will be selected
 					if(shift){
@@ -112,6 +112,10 @@ public class CommandNone implements ActiveCommand{
 			break;
 		}
 		case 1:{
+			// if it didn't meet the drag threshold, don't update
+			if(!view.mouseDragged) {
+				break;
+			}
 			// Selection preview
 			view.restoreBackupSel();
 			boolean shift = view.keys.get(KeyEvent.VK_SHIFT);

--- a/src/com/komiamiko/fcorbit/Main.java
+++ b/src/com/komiamiko/fcorbit/Main.java
@@ -35,6 +35,11 @@ import javax.swing.text.PlainDocument;
 public class Main {
 	
 	/**
+	 * Minimum number of pixels movement to register a mouse drag
+	 */
+	public static final int MOUSE_DRAG_MIN_PIXELS = 4;
+	
+	/**
 	 * Main window
 	 */
 	public static JFrame frame;
@@ -207,7 +212,11 @@ public class Main {
 
 			@Override
 			public void mouseDragged(MouseEvent e) {
-				graphicEditor.mouseDragged = true;
+				if(!graphicEditor.mouseDragged && Math.hypot(
+						e.getX() - graphicEditor.originMousex,
+						e.getY() - graphicEditor.originMousey) >= MOUSE_DRAG_MIN_PIXELS) {
+					graphicEditor.mouseDragged = true;
+				}
 				graphicEditor.command.mouseDragged(e);
 				graphicEditor.lastMousex = e.getX();
 				graphicEditor.lastMousey = e.getY();


### PR DESCRIPTION
This fixes the annoyance when you intend to click but move the cursor ever so slightly and it registers as a mouse drag. It can be quite annoying since the drag select behaviour differs greatly from click select. It happens to me often on my laptop since the trackpad is not such a finely controllable input method. With this change, a minimum amount of movement is required for it to go into drag mode, which I currently set to 4 pixels.