### PR TITLE
Consistent line ordering

### DIFF
--- a/src/com/komiamiko/fcorbit/CommandNone.java
+++ b/src/com/komiamiko/fcorbit/CommandNone.java
@@ -9,6 +9,8 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.HashSet;
 
+import com.komiamiko.fcorbit.document.FCObj;
+
 /**
  * Not a real command, this goes in when there's no command active
  * 

--- a/src/com/komiamiko/fcorbit/CommandTranslate.java
+++ b/src/com/komiamiko/fcorbit/CommandTranslate.java
@@ -5,6 +5,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.AffineTransform;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 
@@ -21,7 +22,7 @@ public class CommandTranslate implements ActiveCommand{
 	public final GraphicEditorPane view;
 	
 	public boolean done = false;
-	public IdentityHashMap<FCObj,FCObj> backupDoc;
+	public FCObj[] backupDoc;
 	public int initialx;
 	public int initialy;
 	
@@ -37,15 +38,17 @@ public class CommandTranslate implements ActiveCommand{
 		this.view = view;
 		initialx = view.lastMousex;
 		initialy = view.lastMousey;
-		backupDoc = new IdentityHashMap<>();
-		for(FCObj obj:view.objSel){
-			backupDoc.put(obj, new FCObj(obj));
+		backupDoc = new FCObj[view.objSel.cardinality()];
+		for(int i = view.objSel.nextSetBit(0), j = 0; i >= 0; i = view.objSel.nextSetBit(i+1), ++j) {
+			FCObj obj = (FCObj)view.objDoc.get(i);
+			backupDoc[j] = new FCObj(obj);
 		}
 	}
 	
 	public void restoreBackupDoc(){
-		for(FCObj obj:view.objSel){
-			FCObj copy = backupDoc.get(obj);
+		for(int i = view.objSel.nextSetBit(0), j = 0; i >= 0; i = view.objSel.nextSetBit(i+1), ++j) {
+			FCObj copy = backupDoc[j];
+			FCObj obj = (FCObj)view.objDoc.get(i);
 			obj.copyFrom(copy);
 		}
 	}
@@ -59,7 +62,7 @@ public class CommandTranslate implements ActiveCommand{
 		double wdy = dy*invScale;
 		switch(direction){
 		case 1:{
-			final double r = Math.toRadians(view.objSel.get(0).r),
+			final double r = view.getPivot()[2],
 					cr = Math.cos(r),
 					sr = Math.sin(r);
 			double wdl = wdx;
@@ -72,7 +75,7 @@ public class CommandTranslate implements ActiveCommand{
 			break;
 		}
 		case -1:{
-			final double r = Math.toRadians(view.objSel.get(0).r),
+			final double r = view.getPivot()[2],
 					cr = Math.cos(r),
 					sr = Math.sin(r);
 			double wdl = wdy;
@@ -93,12 +96,10 @@ public class CommandTranslate implements ActiveCommand{
 		double[] wdxy = getTranslation(mx,my);
 		double wdx = wdxy[0];
 		double wdy = wdxy[1];
-		HashSet<FCObj> hashSel = new HashSet<>(view.objSel);
-		for(FCObj obj:view.objDoc){
-			if(hashSel.contains(obj)){
-				obj.x += wdx;
-				obj.y += wdy;
-			}
+		for(int i = view.objSel.nextSetBit(0), j = 0; i >= 0; i = view.objSel.nextSetBit(i+1), ++j) {
+			FCObj obj = (FCObj)view.objDoc.get(i);
+			obj.x += wdx;
+			obj.y += wdy;
 		}
 	}
 
@@ -118,9 +119,9 @@ public class CommandTranslate implements ActiveCommand{
 		g.translate(cx, cy);
 		g.scale(scale, scale);
 		g.translate(-view.anchorx, -view.anchory);
-		FCObj first = view.objSel.get(0);
-		double ox = first.x;
-		double oy = first.y;
+		double[] pivot = view.getPivot();
+		double ox = pivot[0];
+		double oy = pivot[1];
 		if(direction==0){
 			double[] wdxy = getTranslation(view.lastMousex,view.lastMousey);
 			double wdx = wdxy[0];
@@ -135,8 +136,7 @@ public class CommandTranslate implements ActiveCommand{
 					wdx=1;
 					wdy=0;
 				}else{
-					FCObj obj = view.objSel.get(0);
-					final double r = Math.toRadians(obj.r);
+					final double r = pivot[2];
 					wdx = Math.cos(r);
 					wdy = Math.sin(r);
 				}
@@ -146,13 +146,11 @@ public class CommandTranslate implements ActiveCommand{
 					wdx=0;
 					wdy=1;
 				}else{
-					FCObj obj = view.objSel.get(0);
-					final double r = Math.toRadians(obj.r);
+					final double r = pivot[2];
 					wdx = -Math.sin(r);
 					wdy = Math.cos(r);
 				}
 			}
-			Main.console.println(wdx+" "+wdy);
 			wdx*=RAYLENGTH;
 			wdy*=RAYLENGTH;
 			g.drawLine((int)(ox-wdx), (int)(oy-wdy), (int)(ox+wdx), (int)(oy+wdy));

--- a/src/com/komiamiko/fcorbit/CommandTranslate.java
+++ b/src/com/komiamiko/fcorbit/CommandTranslate.java
@@ -8,6 +8,8 @@ import java.awt.geom.AffineTransform;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 
+import com.komiamiko.fcorbit.document.FCObj;
+
 /**
  * 
  * 

--- a/src/com/komiamiko/fcorbit/GraphicEditorPane.java
+++ b/src/com/komiamiko/fcorbit/GraphicEditorPane.java
@@ -15,9 +15,11 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 
 import javax.swing.JPanel;
 
+import com.komiamiko.fcorbit.document.FCDocumentLine;
 import com.komiamiko.fcorbit.document.FCObj;
 
 /**
@@ -124,9 +126,9 @@ public class GraphicEditorPane extends JPanel implements KeyTracker {
 	 */
 	public boolean showGrid;
 	
-	public ArrayList<FCObj> objDoc;
-	public ArrayList<FCObj> objSel;
-	public ArrayList<FCObj> backupSel = new ArrayList<>();
+	public ArrayList<FCDocumentLine> objDoc;
+	public BitSet objSel;
+	public BitSet backupSel = new BitSet();
 	
 	public ActiveCommand command = new CommandNone(this);
 	
@@ -184,27 +186,24 @@ public class GraphicEditorPane extends JPanel implements KeyTracker {
 		overlays.translate(-anchorx, -anchory);
 		int leveln = -2;
 		// Sort objects
-		objDoc.sort(FCObj.Z_COMPARE);
-		// Grab selection
-		HashMap<FCObj,Integer> selectedIndex = new HashMap<>();
-		int i=0;
-		for(FCObj obj:objSel){
-			selectedIndex.put(obj, i);
-			i++;
+		ArrayList<FCObj> renderObjs = new ArrayList<>();
+		for(FCDocumentLine o:objDoc) {
+			if(o instanceof FCObj) {
+				renderObjs.add((FCObj)o);
+			}
 		}
+		renderObjs.sort(FCObj.Z_COMPARE);
 		// Background
 		g.setColor(BACKGROUND);
 		g.fillRect(0, 0, width, height);
 		// Iterate and draw onto layers
-		for(FCObj obj:objDoc){
+		for(FCObj obj:renderObjs){
 			if(tracker!=Main.ticker)break;
 			int z = obj.z;
 			double x = obj.x, y = obj.y, w = obj.w, h = obj.h, r = obj.r;
 			int typeData = obj.getTypeData();
-			Integer osel = selectedIndex.get(obj);
-			boolean isselected = osel!=null;
-			int sel = isselected?osel:-1;
-			boolean isselectedfirst = sel==0;
+			boolean isselected = objSel.get(obj.getLineNumber());
+			boolean isselectedfirst = false;
 			boolean isdesign = Bits.readBit(typeData, FCObj.TYPE_DESIGN);
 			boolean iscircle = Bits.readBit(typeData, FCObj.TYPE_CIRCLE);
 			boolean isgoal = Bits.readBit(typeData, FCObj.TYPE_GOAL);
@@ -542,9 +541,12 @@ public class GraphicEditorPane extends JPanel implements KeyTracker {
 	}
 	public FCObj getSelectionPointWorld(double wmx,double wmy){
 		ArrayList<FCObj> candidates = new ArrayList<>();
-		for(FCObj obj:objDoc){
-			if(obj.contains(wmx,wmy)){
-				candidates.add(obj);
+		for(FCDocumentLine line:objDoc){
+			if(line instanceof FCObj) {
+				FCObj obj = (FCObj)line;
+				if(obj.contains(wmx,wmy)){
+					candidates.add(obj);
+				}
 			}
 		}
 		if(candidates.isEmpty())return null;
@@ -584,22 +586,61 @@ public class GraphicEditorPane extends JPanel implements KeyTracker {
 		dummy.w = wmx-womx;
 		dummy.h = wmy-womy;
 		ArrayList<FCObj> candidates = new ArrayList<>();
-		for(FCObj obj:objDoc){
-			if(dummy.intersects(obj)){
-				candidates.add(obj);
+		for(FCDocumentLine line:objDoc){
+			if(line instanceof FCObj) {
+				FCObj obj = (FCObj)line;
+				if(dummy.intersects(obj)){
+					candidates.add(obj);
+				}
 			}
 		}
 		return candidates;
 	}
 	
+	/**
+	 * Get the current "pivot" point with orientation as an (X, Y, R) tuple.
+	 * Angle is in radians.
+	 * It is used in various operations:
+	 * <ul>
+	 * <li>Where the centre the view when the "center view" key is used</li>
+	 * <li>Origin/pivot point for rotation tool (future feature)</li>
+	 * <li>Origin/pivot point for scale tool (future feature)</li>
+	 * </ul>
+	 * As currently implemented, it is the world origin if there is no selection,
+	 * otherwise the unweighted median point of all selected objects.
+	 * Orientation will be the orientation of the selected object if there is exactly 1,
+	 * otherwise 0.
+	 * 
+	 * @return
+	 */
+	public double[] getPivot() {
+		int sn = objSel.cardinality();
+		if(sn == 0) {
+			return new double[] {0, 0, 0};
+		}
+		double rx = 0, ry = 0, rr = 0;
+		for(int i = objSel.nextSetBit(0); i >= 0; i = objSel.nextSetBit(i+1)) {
+			FCObj obj = (FCObj)objDoc.get(i);
+			rx += obj.x;
+			ry += obj.y;
+			if(sn == 1) {
+				rr = Math.toRadians(obj.r);
+			}
+		}
+		double mul = 1d / sn;
+		rx *= mul;
+		ry *= mul;
+		return new double[] {rx, ry, rr};
+	}
+	
 	public void setBackupSel(){
 		backupSel.clear();
-		backupSel.addAll(objSel);
+		backupSel.or(objSel);
 	}
 	
 	public void restoreBackupSel(){
 		objSel.clear();
-		objSel.addAll(backupSel);
+		objSel.or(backupSel);
 	}
 	
 	public void tryUndo(){

--- a/src/com/komiamiko/fcorbit/GraphicEditorPane.java
+++ b/src/com/komiamiko/fcorbit/GraphicEditorPane.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 
 import javax.swing.JPanel;
 
+import com.komiamiko.fcorbit.document.FCObj;
+
 /**
  * The graphical editor component
  * 

--- a/src/com/komiamiko/fcorbit/Main.java
+++ b/src/com/komiamiko/fcorbit/Main.java
@@ -26,6 +26,8 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
 import javax.swing.text.PlainDocument;
 
+import com.komiamiko.fcorbit.document.FCObj;
+
 /**
  * The main class
  * 

--- a/src/com/komiamiko/fcorbit/Main.java
+++ b/src/com/komiamiko/fcorbit/Main.java
@@ -253,12 +253,14 @@ public class Main {
 	
 	public static void parseTextTo(String source,ArrayList<FCObj> target,String format){
 		if(source==null)return;
+		int lineCounter = 0;
 		for(String line:source.split("\n")){
 			try{
-				target.add(new FCObj(line,format));
+				target.add(new FCObj(line,format,lineCounter));
 			}catch(Exception e){
 				
 			}
+			lineCounter++;
 		}
 	}
 	
@@ -303,14 +305,16 @@ public class Main {
 	
 	public static void updateTextDocumentFromObj(){
 		StringBuilder sb = new StringBuilder();
+		int lineCounter = 0;
 		for(String line:textEditor.getText().split("\n")){
 			try{
 				// Dummy object
-				new FCObj(line,"fcml");
+				new FCObj(line,"fcml",lineCounter);
 			}catch(Exception e){
 				sb.append(line);
 				sb.append('\n');
 			}
+			lineCounter++;
 		}
 		for(FCObj obj:objDoc){
 			sb.append(obj.toString("fcml"));
@@ -332,9 +336,10 @@ public class Main {
 			int first = 0;
 			boolean chain = false;
 			int pos = 0;
+			int lineCounter = 0;
 			for(String line:textEditor.getText().split("\n")){
 				try{
-					FCObj other = new FCObj(line,"fcml");
+					FCObj other = new FCObj(line,"fcml",lineCounter);
 					if(ref.equals(other)){
 						if(!chain)first = pos;
 						chain = true;
@@ -351,6 +356,7 @@ public class Main {
 					
 				}
 				pos += line.length()+1;
+				lineCounter++;
 			}
 		}
 		ticker++;

--- a/src/com/komiamiko/fcorbit/Main.java
+++ b/src/com/komiamiko/fcorbit/Main.java
@@ -332,6 +332,7 @@ public class Main {
 	}
 	
 	public static void updateTextDocumentFromObj(){
+		fixLineNumbers(objDoc);
 		StringBuilder sb = new StringBuilder();
 		for(FCDocumentLine obj:objDoc){
 			sb.append(obj.toString());

--- a/src/com/komiamiko/fcorbit/Main.java
+++ b/src/com/komiamiko/fcorbit/Main.java
@@ -26,6 +26,8 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
 import javax.swing.text.PlainDocument;
 
+import com.komiamiko.fcorbit.document.CommentLine;
+import com.komiamiko.fcorbit.document.FCDocumentLine;
 import com.komiamiko.fcorbit.document.FCObj;
 
 /**
@@ -71,11 +73,11 @@ public class Main {
 	/**
 	 * Editor internal document
 	 */
-	public static ArrayList<FCObj> objDoc;
+	public static ArrayList<FCDocumentLine> objDoc;
 	/**
 	 * Editor internal selection
 	 */
-	public static ArrayList<FCObj> objSel;
+	public static BitSet objSel;
 	/**
 	 * Changes every update, used to track idling
 	 */
@@ -98,7 +100,7 @@ public class Main {
 		textEditor = new TextEditorPane(textDoc,"",150,150);
 		textSel = textEditor.getSelectedText();
 		objDoc = new ArrayList<>();
-		objSel = new ArrayList<>();
+		objSel = new BitSet();
 		textUndo = new TimedUndoManagerV2();
 		// Do layout
 		textEditorScroll.setViewportView(textEditor);
@@ -251,14 +253,14 @@ public class Main {
 		});
 	}
 	
-	public static void parseTextTo(String source,ArrayList<FCObj> target,String format){
+	public static void parseTextTo(String source,ArrayList<FCDocumentLine> target,String format){
 		if(source==null)return;
 		int lineCounter = 0;
 		for(String line:source.split("\n")){
 			try{
 				target.add(new FCObj(line,format,lineCounter));
 			}catch(Exception e){
-				
+				target.add(new CommentLine(line,lineCounter));
 			}
 			lineCounter++;
 		}
@@ -278,18 +280,44 @@ public class Main {
 	}
 	
 	public static void updateObjSelectionFromText(){
-		String text = textEditor.getSelectedText();
+		int tsStart = textEditor.getSelectionStart();
+		int tsStop = textEditor.getSelectionEnd();
 		objSel.clear();
-		parseTextTo(text,objSel,"fcml");
-		int sn = objSel.size();
-		// Ensure objects are same reference
-		HashMap<FCObj,FCObj> swap = new HashMap<>();
-		for(FCObj obj:objDoc){
-			swap.put(obj, obj);
-		}
-		for(int i=0;i<sn;i++){
-			FCObj obj = swap.get(objSel.get(i));
-			if(obj!=null)objSel.set(i, obj);
+		// empty case
+		if(tsStart < tsStop) {
+			String text = textEditor.getText();
+			int docLength = text.length();
+			// skip over whitespace, including empty lines
+			while(tsStart < tsStop && text.charAt(tsStart) <= ' ') {
+				tsStart++;
+			}
+			while(tsStart < tsStop && text.charAt(tsStop - 1) <= ' ') {
+				tsStop--;
+			}
+			// stop early if selection is empty
+			if(tsStart < tsStop) {
+				// count newlines in range
+				int nlLeft = 0, nlMid = 0;
+				for(int i = 0; i < tsStart; ++i) {
+					if(text.charAt(i) == '\n') {
+						nlLeft++;
+					}
+				}
+				for(int i = tsStart; i < tsStop; ++i) {
+					if(text.charAt(i) == '\n') {
+						nlMid++;
+					}
+				}
+				// determine start/stop of the selection
+				int selStart = nlLeft;
+				int selStop = nlLeft + nlMid + 1;
+				// set selection only for fc object lines
+				for(int i = selStart; i < selStop; ++i) {
+					if(objDoc.get(i) instanceof FCObj) {
+						objSel.set(i);
+					}
+				}
+			}
 		}
 		ticker++;
 		graphicEditor.setBackupSel();
@@ -305,19 +333,8 @@ public class Main {
 	
 	public static void updateTextDocumentFromObj(){
 		StringBuilder sb = new StringBuilder();
-		int lineCounter = 0;
-		for(String line:textEditor.getText().split("\n")){
-			try{
-				// Dummy object
-				new FCObj(line,"fcml",lineCounter);
-			}catch(Exception e){
-				sb.append(line);
-				sb.append('\n');
-			}
-			lineCounter++;
-		}
-		for(FCObj obj:objDoc){
-			sb.append(obj.toString("fcml"));
+		for(FCDocumentLine obj:objDoc){
+			sb.append(obj.toString());
 			sb.append('\n');
 		}
 		textEditor.setText(sb.toString());
@@ -327,40 +344,81 @@ public class Main {
 	
 	public static void updateTextSelectionFromObj(){
 		graphicEditor.setBackupSel();
-		int sn = objSel.size();
+		int sn = objSel.cardinality();
+		// check not empty
 		if(sn>0){
-			ArrayList<FCObj> sortedSel = new ArrayList<>(objSel);
-			Mapping.sort(sortedSel, (FCObj value)->objDoc.indexOf(value), Comparator.<Integer>naturalOrder());
-			int i = 0;
-			FCObj ref = sortedSel.get(i);
-			int first = 0;
-			boolean chain = false;
-			int pos = 0;
-			int lineCounter = 0;
-			for(String line:textEditor.getText().split("\n")){
-				try{
-					FCObj other = new FCObj(line,"fcml",lineCounter);
-					if(ref.equals(other)){
-						if(!chain)first = pos;
-						chain = true;
-						i++;
-						if(i==sn){
-							textEditor.select(first, pos+line.length());
-							break;
-						}
-						ref = sortedSel.get(i);
-					}else if(chain){
-						break;
-					}
-				}catch(Exception e){
-					
+			// check contiguous
+			// if they are contiguous, it will look like
+			// 0 ... 0 1 ... 1 0 ... 0
+			// so the first 0 after the first 1 should be just after the last 1
+			final int firstSet = objSel.nextSetBit(0);
+			final int lastSet = objSel.previousSetBit(objSel.length());
+			final int nextClear = objSel.nextClearBit(firstSet);
+			if(nextClear == lastSet + 1) {
+				final int selStart = firstSet;
+				final int selStop = nextClear;
+				// calculate positions in text
+				int tsStart = selStart;
+				String[] lines = textEditor.getText().split("\n");
+				for(int i = 0; i < selStart; ++i) {
+					tsStart += lines[i].length();
 				}
-				pos += line.length()+1;
-				lineCounter++;
+				int tsStop = tsStart + selStop - selStart - 1;
+				for(int i = selStart; i < selStop; ++i) {
+					tsStop += lines[i].length();
+				}
+				// temporarily set start to 0 to prevent bounds issues
+				textEditor.setSelectionStart(0);
+				// set stop
+				textEditor.setSelectionEnd(tsStop);
+				// set start
+				textEditor.setSelectionStart(tsStart);
 			}
 		}
 		ticker++;
 		textEditor.repaint();
+	}
+	
+	/**
+	 * Normalize line numbers in-place
+	 * 
+	 * @see FCDocumentLine#getLineNumber()
+	 * 
+	 * @param target document as list of lines
+	 */
+	public static void fixLineNumbers(ArrayList<FCDocumentLine> target) {
+		int lineCounter = 0;
+		for(FCDocumentLine line:target) {
+			line.setLineNumber(lineCounter, 0);
+			lineCounter++;
+		}
+	}
+	
+	/**
+	 * Apply a change to the object document. This can be summarized in 4 steps:
+	 * <ol>
+	 * <li>Delete all objects in the original selection</li>
+	 * <li>Insert all new objects at the end</li>
+	 * <li>Sort by line/subline, which fixes the ordering</li>
+	 * <li>Normalize the line numbers using {@link #fixLineNumbers(ArrayList)}</li>
+	 * </ol>
+	 * Note that any selected and unchanged objects need to be explicitly re-included.
+	 * 
+	 * @param target document to modify
+	 * @param selection object selection
+	 * @param toAdd new objects to add
+	 */
+	public static void applyObjDocumentChange(ArrayList<FCDocumentLine> target, BitSet selection, ArrayList<FCDocumentLine> toAdd) {
+		// delete original selected objects
+		for(int i = selection.length(); (i = selection.previousSetBit(i-1)) >= 0;) {
+			target.remove(i);
+		}
+		// append new objects
+		target.addAll(toAdd);
+		// sort by line number
+		target.sort(FCDocumentLine.COMPARE_LINE_NUMBER);
+		// normalize line numbers
+		fixLineNumbers(target);
 	}
 	
 	public static void tryUndo(){

--- a/src/com/komiamiko/fcorbit/document/CommentLine.java
+++ b/src/com/komiamiko/fcorbit/document/CommentLine.java
@@ -1,0 +1,74 @@
+package com.komiamiko.fcorbit.document;
+
+import java.util.Objects;
+
+/**
+ * Represents a comment line, which is any line that does not
+ * represent an FC object.
+ * 
+ * @author komiamiko
+ * @version 1.0
+ */
+public class CommentLine implements FCDocumentLine {
+	
+	/**
+	 * Line number, as would be returned by {@link #getLineNumber()}
+	 */
+	protected int line;
+	/**
+	 * Sub-line number, as would be returned by {@link #getSubLineNumber()}
+	 */
+	protected int subline;
+	/**
+	 * The text of this line.
+	 */
+	public String text;
+	
+	/**
+	 * Usual constructor, with text and line number.
+	 * 
+	 * @param text text of the line
+	 * @param line line number
+	 */
+	public CommentLine(String text, int line) {
+		this.text = text;
+		setLineNumber(line, 0);
+	}
+
+	@Override
+	public int getLineNumber() {
+		return line;
+	}
+
+	@Override
+	public int getSubLineNumber() {
+		return subline;
+	}
+
+	@Override
+	public void setLineNumber(int line, int subline) {
+		this.line = line;
+		this.subline = subline;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(text);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!(obj instanceof CommentLine))
+			return false;
+		CommentLine other = (CommentLine) obj;
+		return Objects.equals(text, other.text);
+	}
+	
+	@Override
+	public String toString() {
+		return text;
+	}
+
+}

--- a/src/com/komiamiko/fcorbit/document/FCDocumentLine.java
+++ b/src/com/komiamiko/fcorbit/document/FCDocumentLine.java
@@ -1,0 +1,44 @@
+package com.komiamiko.fcorbit.document;
+
+/**
+ * Dummy type to act as a union between text lines
+ * representing FC objects and other text lines.
+ * 
+ * @author komiamiko
+ * @version 1.0
+ */
+public interface FCDocumentLine {
+	
+	/**
+	 * Get the line number within the document.
+	 * <br>
+	 * Lines are sorted by lexicographic order on (line, subline).
+	 * After any operation is finalized, the line numbers are always
+	 * normalized so that line counts up and subline = 0.
+	 * In an intermediate step, subline may be useful to instruct
+	 * the editor to insert multiple lines at a location.
+	 * <br>
+	 * Line number is not to be used in equality or hashing.
+	 * 
+	 * @return the line number
+	 */
+	public int getLineNumber();
+	
+	/**
+	 * Get the sub-line number.
+	 * 
+	 * @see FCDocumentLine#getLineNumber()
+	 * 
+	 * @return the sub-line number
+	 */
+	public int getSubLineNumber();
+	
+	/**
+	 * Set the line number and sub-line number at once.
+	 * 
+	 * @param line
+	 * @param subline
+	 */
+	public void setLineNumber(int line, int subline);
+	
+}

--- a/src/com/komiamiko/fcorbit/document/FCDocumentLine.java
+++ b/src/com/komiamiko/fcorbit/document/FCDocumentLine.java
@@ -1,5 +1,7 @@
 package com.komiamiko.fcorbit.document;
 
+import java.util.Comparator;
+
 /**
  * Dummy type to act as a union between text lines
  * representing FC objects and other text lines.
@@ -9,12 +11,16 @@ package com.komiamiko.fcorbit.document;
  */
 public interface FCDocumentLine {
 	
+	public static final Comparator<FCDocumentLine> COMPARE_LINE_NUMBER =
+			Comparator.comparingInt(FCDocumentLine::getLineNumber)
+			.thenComparingInt(FCDocumentLine::getSubLineNumber);
+	
 	/**
 	 * Get the line number within the document.
 	 * <br>
 	 * Lines are sorted by lexicographic order on (line, subline).
 	 * After any operation is finalized, the line numbers are always
-	 * normalized so that line counts up and subline = 0.
+	 * normalized so that line counts up from 0 and subline = 0.
 	 * In an intermediate step, subline may be useful to instruct
 	 * the editor to insert multiple lines at a location.
 	 * <br>

--- a/src/com/komiamiko/fcorbit/document/FCObj.java
+++ b/src/com/komiamiko/fcorbit/document/FCObj.java
@@ -5,6 +5,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Objects;
 
+import com.komiamiko.fcorbit.Bits;
+import com.komiamiko.fcorbit.Floats;
+
 /**
  * Represents a game object
  * <br>

--- a/src/com/komiamiko/fcorbit/document/FCObj.java
+++ b/src/com/komiamiko/fcorbit/document/FCObj.java
@@ -16,7 +16,7 @@ import com.komiamiko.fcorbit.Floats;
  * @author EPICI
  * @version 1.0
  */
-public class FCObj {
+public class FCObj implements FCDocumentLine {
 	
 	/**
 	 * Comparator using the object z value, useful for sorting
@@ -189,6 +189,14 @@ public class FCObj {
 	 * If another object's z value is in this list, then they are connected
 	 */
 	public ArrayList<Integer> joints = new ArrayList<>();
+	/**
+	 * Line number, as retrieved by {@link #getLineNumber()}
+	 */
+	protected int line;
+	/**
+	 * Sub-line number, as retrieved by {@link #getSubLineNumber()}
+	 */
+	protected int subline;
 	
 	/**
 	 * Default constructor, does nothing
@@ -211,8 +219,9 @@ public class FCObj {
 	 * 
 	 * @param text text containing a single FC object
 	 * @param format string to indicate the format used
+	 * @param lineNumber the line number
 	 */
-	public FCObj(String text,String format){
+	public FCObj(String text,String format,int lineNumber){
 		switch(format){
 		case "fcml":{
 			String[] tokens = text.split("[\\s(),\\[\\]]+");
@@ -249,6 +258,7 @@ public class FCObj {
 			throw new IllegalArgumentException("FC object format \""+format+"\" not known");
 		}
 		}
+		setLineNumber(lineNumber, 0);
 	}
 	
 	/**
@@ -267,6 +277,8 @@ public class FCObj {
 		r=source.r;
 		joints.clear();
 		joints.addAll(source.joints);
+		line = source.getLineNumber();
+		subline = source.getSubLineNumber();
 	}
 	
 	@Override
@@ -516,6 +528,19 @@ public class FCObj {
 			}
 		}
 		return true;
+	}
+	@Override
+	public int getLineNumber() {
+		return line;
+	}
+	@Override
+	public int getSubLineNumber() {
+		return subline;
+	}
+	@Override
+	public void setLineNumber(int line, int subline) {
+		this.line = line;
+		this.subline = subline;
 	}
 	
 }

--- a/src/com/komiamiko/fcorbit/document/FCObj.java
+++ b/src/com/komiamiko/fcorbit/document/FCObj.java
@@ -1,4 +1,4 @@
-package com.komiamiko.fcorbit;
+package com.komiamiko.fcorbit.document;
 
 import java.util.ArrayList;
 import java.util.Comparator;


### PR DESCRIPTION
Fixes #2 

# What the user sees
Lines no longer get rearranged for no reason when doing stuff in the graphical editor.

# Notable code changes
* Object document is now a list of `FCDocumentLine`, which is implemented by both `FCObj` and `CommentLine`
* Object document contains both actual FC objects as `FCObj` and plain text as `CommentLine`
* Object selection is now a `BitSet` which acts as a mask on the object document
* Since the object selection is a bitset, which has no order, there is no longer a concept of "first selected object"
* Certain operations which need a pivot point or reference orientation should now call `view.getPivot()` which returns (X, Y, R) tuple
* `FCDocumentLine` interface provides line numbers
* Features added from here on out are expected to respect the line numbers and use them appropriately

# Things broken
I needed to cut out some things since there is no longer a concept of "first selected object" which was previously used like a pivot. To make the loss less noticeable, I added a very barebones pivot feature. This will get expanded someday, and it will be quite a lot more powerful than the old implicit pivot system going on.